### PR TITLE
Improved performance and timing

### DIFF
--- a/___58c60h.c
+++ b/___58c60h.c
@@ -1,6 +1,7 @@
 #include "drally.h"
 
 unsigned int __GET_FRAME_COUNTER(void);
+void __PRESENTSCREEN__(void);
 
 // WAIT 1 FRAME
 void ___58c60h(void){
@@ -8,5 +9,6 @@ void ___58c60h(void){
 	__DWORD__ 	n;
 
 	n = __GET_FRAME_COUNTER();
+	__PRESENTSCREEN__();
 	while(n == __GET_FRAME_COUNTER());
 }

--- a/drally_linux_c.c
+++ b/drally_linux_c.c
@@ -73,7 +73,7 @@ unsigned int __GET_FRAME_COUNTER(void){
 		INT8_FRAME_COUNTER += skip;
 		IRQ0_TimerISR();
 
-		if(!skip) __PRESENTSCREEN__();
+		//if(!skip) __PRESENTSCREEN__();
 	}
 
 	IO_Loop();

--- a/race___478c8h_p.c
+++ b/race___478c8h_p.c
@@ -260,7 +260,7 @@ void race___478c8h(__DWORD__ A1){
 		resetCounter(5);
 		___58c60h();
 		memcpy(VGA13_ACTIVESCREEN+0x5000, ___2432d8h+0x5000, 0xaa00);
-		__VGA13_PRESENTSCREEN__();
+		//__VGA13_PRESENTSCREEN__();
 		memcpy(___2432d8h+0x5000, ___2432d4h+0x5000, 0xaa00);
 		___47304h();
 		D(___24330ch) = getCounter(2);
@@ -303,7 +303,7 @@ void race___478c8h(__DWORD__ A1){
 		resetCounter(2);
 		___58c60h();
 		memcpy(VGA13_ACTIVESCREEN, ___2432d8h, 0xfa00);
-		__VGA13_PRESENTSCREEN__();
+		//__VGA13_PRESENTSCREEN__();
 		memcpy(___2432d8h, ___2432d4h, 0xfa00);
 		if(___47620h() >= i) break;
 		D(___24330ch) = getCounter(2);

--- a/race_main.c
+++ b/race_main.c
@@ -672,8 +672,10 @@ void race_main(int MyIndex, int NumCars){		// my_position_index, number_of_racer
 			D(___243d14h) = 1;
 		}
 
+		/*
 		D(___243d08h) = __GET_FRAME_COUNTER();
 		while(D(___243d08h) == __GET_FRAME_COUNTER());
+		*/
 
 		if((int)s_35e[MY_CAR_IDX].Drug > 0){
 

--- a/race_main.c
+++ b/race_main.c
@@ -218,7 +218,7 @@ void race_main(int MyIndex, int NumCars){		// my_position_index, number_of_racer
 
 	__DWORD__ 	eax, ebx, ecx, edx;
 	__BYTE__ 	esp[0x1c];
-	int 	i, j, n, bool_tmp, k, m, c;
+	int 	i, j, n, bool_tmp, k, m, c, frames;
 	struct_35e_t *	s_35e;
 	struct_94_t * 	s_94;
 	struct_54_t *	s_54;
@@ -612,6 +612,8 @@ void race_main(int MyIndex, int NumCars){		// my_position_index, number_of_racer
 #endif // DR_MULTIPLAYER
 		}
 
+		frames = __GET_FRAME_COUNTER();
+
 		race___4ee9ch();
 		race___4f030h();
 
@@ -676,10 +678,12 @@ void race_main(int MyIndex, int NumCars){		// my_position_index, number_of_racer
 		D(___243d08h) = __GET_FRAME_COUNTER();
 		while(D(___243d08h) == __GET_FRAME_COUNTER());
 		*/
+		while (frames == __GET_FRAME_COUNTER());
 
 		if((int)s_35e[MY_CAR_IDX].Drug > 0){
 
 			race___454ach();
+			__VGA13_PRESENTSCREEN__();
 		}
 		else {
 


### PR DESCRIPTION
I had some performance problems on Windows that I traced back to the screen updates __GET_FRAME_COUNTER. The animation code calls this function a lot, so the overhead ended up being quite significant. I moved the screen update to the ___58c60h function, so the menus all still work.
Another change I made was removing the 1 frame delay in the race_main function. It's not necessary since __GET_FRAME_COUNTER already throttles the game to the correct speed, and the framerate is more stable without it.