### PR TITLE
Death Rally (Classic) Steam version support

### DIFF
--- a/___3e3cch.c
+++ b/___3e3cch.c
@@ -10,9 +10,10 @@ void ___3e3cch(void){
 
     if(!(fd = strupr_fopen("CDROM.INI", "rb"))){
 
-        printf("Error reading CDROM.INI file!\n");
-        dRally_System_clean();
-        exit(0x70);
+        //printf("Error reading CDROM.INI file!\n");
+        //dRally_System_clean();
+        //exit(0x70);
+        return;
     }
 
     fscanf(fd, "%s", ___1a0d60h);

--- a/drally.h
+++ b/drally.h
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <math.h>
 #include <time.h>
+#include <ctype.h>
 #include <SDL2/SDL.h>
 
 #include "types.h"


### PR DESCRIPTION
The freeware release on Steam had a couple of issues that prevented it from working with dRally. It's missing CDROM.INI, the cinematics are simply put in the same folder as the rest of the game data. The other problem was that dr.cfg is not encoded. I added a simple check looking for non-printable characters in the player names to see if the config is encoded.