### PR TITLE
Fixed building without DR_MULTIPLAYER

### DIFF
--- a/___198a0h.c
+++ b/___198a0h.c
@@ -51,6 +51,7 @@ void dRChatbox_push(const char * line, int col);
 // Network Initialize Game
 __DWORD__ ___198a0h(void){
 
+#if defined(DR_MULTIPLAYER)
     __DWORD__   	eax, ebx, ecx, edx, esi;
     __BYTE__    	esp[0x110];
 	__POINTER__ 	vp0, vp1;
@@ -403,4 +404,7 @@ __DWORD__ ___198a0h(void){
 
         return 0;
     }
+#else
+    return 0;
+#endif
 }

--- a/___1c374h.c
+++ b/___1c374h.c
@@ -44,6 +44,7 @@ static __BYTE__ __dfr_1855c8h[0x100] = {
 // Multiplayer Initialize A New Game
 void ___1c374h_cdecl(int A0){
 
+#if defined(DR_MULTIPLAYER)
 	__DWORD__ 	eax, ebx, ecx, edx, edi, esi, ebp;
 	__BYTE__ 	esp[0xc];
 	int 	n;
@@ -141,4 +142,5 @@ void ___1c374h_cdecl(int A0){
 			if(n == -1) break;
 		}
 	}
+#endif
 }

--- a/___1caf4h.c
+++ b/___1caf4h.c
@@ -47,6 +47,7 @@ __DWORD__ ___1caf4h(void){
 
 	if(CONNECTION_TYPE == 2){
 
+#if defined(DR_MULTIPLAYER)
 		if(NovellNetWare_IPX_InstallationCheck() == 0){
 
 			memcpy(___1a112ch__VESA101_ACTIVESCREEN_PTR+0x10680, ___1a1138h__VESA101_BACKGROUND+0x10680, 0x28f00);
@@ -70,9 +71,7 @@ __DWORD__ ___1caf4h(void){
 
 		if(___61cd0h() == 0) ___1123ch();
 
-#if defined(DR_MULTIPLAYER)
 		___19bd60h = 1;
-#endif // DR_MULTIPLAYER
 
 		memcpy(___1a112ch__VESA101_ACTIVESCREEN_PTR+0x10680, ___1a1138h__VESA101_BACKGROUND+0x10680, 0x28f00);
 		___13710h(0, 0);
@@ -123,6 +122,7 @@ __DWORD__ ___1caf4h(void){
 		___12cb8h__VESA101_PRESENTSCREEN();
 		___59b3ch();
 		___5994ch();
+#endif // DR_MULTIPLAYER
 
 		return 1;
 	}

--- a/___1e4f8h.c
+++ b/___1e4f8h.c
@@ -57,13 +57,13 @@ void ___1e4f8h(void){
 
 	if(CONNECTION_TYPE == 2){
 
+#if defined(DR_MULTIPLAYER)
 		___623d4h();
 		edx = D(___199f9ch);
 		D(___199f9ch) = 0;
 
 		if(___61cd0h() == 0) ___1123ch();
 
-#if defined(DR_MULTIPLAYER)
 		if(___19bd60h != 0){
 
 			if(CONNECTION_TYPE == 2){

--- a/__dfr_1d2a8h.c
+++ b/__dfr_1d2a8h.c
@@ -39,6 +39,7 @@ __DWORD__ ___3ab5ch_cdecl(__DWORD__);
 
 void ___1d2a8h(void){
 
+#if defined(DR_MULTIPLAYER)
 	__DWORD__ 	eax, ebx, ecx, edx, edi, esi, ebp;
 	__BYTE__ 	esp[0xc];
 
@@ -128,4 +129,5 @@ void ___1d2a8h(void){
 	
 		___1d4e8h();
 	}
+#endif
 }

--- a/__mp_61518h.c
+++ b/__mp_61518h.c
@@ -48,6 +48,7 @@ void ___61518h(void){
 
 	if(CONNECTION_TYPE == 2){
 
+#if defined(DR_MULTIPLAYER)
 		NovellNetWare_IPX_RelinquishControl();
 
 		n = 0x10;
@@ -71,5 +72,6 @@ void ___61518h(void){
 				if(NovellNetWare_IPX_ListenForPacket(___24cd60h[n])) MP_ERROR = 0xcb;
 			}
 		}
+#endif
 	}
 }

--- a/__mp_6168ch.c
+++ b/__mp_6168ch.c
@@ -56,7 +56,9 @@ void ___618c4h(void){
 
     if(n > 0) ___618c4h_helper(n);
 
+#if defined(DR_MULTIPLAYER)
     if(CONNECTION_TYPE == 2) NovellNetWare_IPX_RelinquishControl();
+#endif // DR_MULTIPLAYER
 }
 
 void ___6168ch(void){
@@ -65,6 +67,7 @@ void ___6168ch(void){
 
 	if(CONNECTION_TYPE == 2){
 
+#if defined(DR_MULTIPLAYER)
 		n = 0x10;
 		while(n--){
 
@@ -85,6 +88,7 @@ void ___6168ch(void){
 				if(NovellNetWare_IPX_ListenForPacket(___24cd60h[n])) MP_ERROR = 0xcb;
 			}
 		}
+#endif // DR_MULTIPLAYER
 	}
 	
 	___618c4h();

--- a/__mp_61cd0h.c
+++ b/__mp_61cd0h.c
@@ -51,6 +51,7 @@ __DWORD__ ___61cd0h(void){
 
     if(CONNECTION_TYPE == 2){
 
+#if defined(DR_MULTIPLAYER)
         if(!(___24e4b4h = (IPX_Address *)dRMemory_alloc(sizeof(IPX_Address)))) return (CONNECTION_TYPE = !(MP_ERROR = 0x64));
         if(!(___24e54eh = (IPX_EventControlBlock *)dRMemory_alloc(sizeof(IPX_EventControlBlock)+2*sizeof(IPX_Fragment)))) return (CONNECTION_TYPE = !(MP_ERROR = 0x64));
         if(!(___24e45ch = (IPX_EventControlBlock *)dRMemory_alloc(sizeof(IPX_EventControlBlock)+2*sizeof(IPX_Fragment)))) return (CONNECTION_TYPE = !(MP_ERROR = 0x64));
@@ -87,6 +88,7 @@ __DWORD__ ___61cd0h(void){
 			if(NovellNetWare_IPX_ListenForPacket(___24cd60h[n])) MP_ERROR = 0xcb;
             ___24cd60h[n]->InUse = ECB_INUSE_AWAITINGPACKET;
 		}
+#endif // DR_MULTIPLAYER
 	}
 
 	_dos_gettime(&esp);


### PR DESCRIPTION
The game now builds if DR_MULTIPLAYER is not defined. I also put some ifdefs around multiplayer-only code so they can be trimmed off the executable. 