### PR TITLE
Removed 64-bit divisions and multiplications

### DIFF
--- a/___17510h.c
+++ b/___17510h.c
@@ -39,7 +39,6 @@ void ___12e78h_cdecl(__BYTE__ * A1, font_props_t * A2, const char * A3, __DWORD_
 __DWORD__ ___17510h_cdecl(__POINTER__ A1, __DWORD__ A2, __DWORD__ A3, __POINTER__ A4, __DWORD__ A5, __DWORD__ A6, __DWORD__ A7, __DWORD__ A8, __DWORD__ A9){
 
 	int 	n;
-	long long 	ll_tmp;
 	__DWORD__ 	eax, eax1, eax2, ebx, ecx, edx, edi, esi, ebp;
 	__BYTE__ 	esp[0x9c+0xc+4+0x14];
 	int 	i, j;

--- a/___190c4h.c
+++ b/___190c4h.c
@@ -34,12 +34,7 @@ void ___3892ch_cdecl(__DWORD__);
 
 static __DWORD__ helper00(__DWORD__ eax, __DWORD__ edx){
 
-	long long 	ll_tmp;
-
-	ll_tmp = (long long)(int)eax*(int)edx; edx = ll_tmp>>0x20; eax = ll_tmp;
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax >> 0x10)|(edx << 0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax = (int)eax>>0x10;
 	eax &= 0xff;
@@ -65,7 +60,7 @@ void ___190c4h(void){
 		edx = ebp;
 		eax = ebp;
 		edx = (int)edx>>0x1f;
-		edx = (long long)(int)eax%(int)esi;
+		edx = (int)eax%(int)esi;
 		
 		if(edx != 0) menu___13a98h(1);	// SPINNING TIRE ICON
 
@@ -119,7 +114,7 @@ void ___190c4h(void){
 		edx = ebp;
 		eax = ebp;
 		edx = (int)edx>>0x1f;
-		edx = (long long)(int)eax%(int)esi;
+		edx = (int)eax%(int)esi;
 
 		if(edx != 0) menu___13a98h(1);	// SPINNING TIRE ICON
 

--- a/___2415ch.c
+++ b/___2415ch.c
@@ -41,7 +41,6 @@ const char name_list[0x14][0xb] = {
 void ___2415ch(void){
 
 
-	long long 	ll_tmp;
 	__DWORD__ 	eax, ebx, ecx, edx, edi, esi, ebp, n;
 	__BYTE__ 	esp[0x100];
 	racer_t * 	s_6c;

--- a/___269e4h.c
+++ b/___269e4h.c
@@ -169,15 +169,11 @@ void ___269e4h(void){
 
 		if(D(___185a14h_UseWeapons) == 0){
 
-			eax = D(0x6e0*s_6c[D(___1a1ef8h)].car+___18e298h+0x6dc);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0xa);
+			eax = D(0x6e0 * s_6c[D(___1a1ef8h)].car + ___18e298h + 0x6dc) / 0xa;
 		}
 		else {
 
-			eax = D(0x6e0*s_6c[D(___1a1ef8h)].car+___18e298h+0x6dc);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0xa);
+			eax = D(0x6e0 * s_6c[D(___1a1ef8h)].car + ___18e298h + 0x6dc) / 0xa;
 			edx = eax;
 			edx = (int)edx>>0x1f;
 			eax = eax-edx;

--- a/___2b5f0h.c
+++ b/___2b5f0h.c
@@ -11,10 +11,7 @@ typedef struct x655_s {
 
 static __BYTE__ helper_color(__DWORD__ eax, __DWORD__ edx){
 	
-	___imul32((__POINTER__)&eax, (__POINTER__)&edx, edx);
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax >> 0x10)|(edx << 0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax = (int)eax>>0x10;
 

--- a/___31008h.c
+++ b/___31008h.c
@@ -72,10 +72,7 @@ void __DISPLAY_SET_PALETTE_COLOR(__DWORD__ b, __DWORD__ g, __DWORD__ r, __DWORD_
 
 static __BYTE__ helper_color(__DWORD__ eax, __DWORD__ edx){
 
-	___imul32((__POINTER__)&eax, (__POINTER__)&edx, edx);
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax >> 0x10)|(edx << 0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax= (int)eax>>0x10;
 

--- a/___31868h.c
+++ b/___31868h.c
@@ -40,8 +40,7 @@ __DWORD__ ___31868h(void){
 	rslt = 0;
 
 	eax = rand_watcom106();
-	edx = (int)eax>>0x1f;
-	___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x64);
+	edx = eax % 0x64;
 	rslt = 0;
 
 	if(((int)edx >= (int)D(___196b24h))||(D(___185a14h_UseWeapons) == 0)){
@@ -52,8 +51,7 @@ __DWORD__ ___31868h(void){
 
 		D(___196b24h) = 5;
 		eax = rand_watcom106();
-		edx = (int)eax>>0x1f;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x64);
+		edx = eax % 0x64;
 	
 		if((int)edx >= 0x32){
 
@@ -128,8 +126,7 @@ __DWORD__ ___31868h(void){
 			while(1){
 
 				eax = rand_watcom106();
-				edx = (int)eax>>0x1f;
-				___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 4);
+				edx = eax % 4;
 				eax = B(___1a0ef8h+4*D(___1a1028h)+edx);
 				if(eax != D(___1a1ef8h)) break;
 			}

--- a/___3266ch.c
+++ b/___3266ch.c
@@ -67,14 +67,7 @@ void __DISPLAY_SET_PALETTE_COLOR(__DWORD__, __DWORD__, __DWORD__, __DWORD__);
 
 static __DWORD__ helper_color(__DWORD__ eax, __DWORD__ edx){
 
-	long long 	ll_tmp;
-
-	ll_tmp = (long long)(int)eax*(int)edx;
-	edx = ll_tmp>>0x20;
-	eax = ll_tmp;
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax >> 0x10)|(edx << 0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax = (int)eax>>0x10;
 	eax &= 0xff;

--- a/___36358h.c
+++ b/___36358h.c
@@ -34,10 +34,7 @@ void ___35f34h_cdecl(__DWORD__, __DWORD__, __DWORD__);
 
 static __BYTE__ helper_color(__DWORD__ eax, __DWORD__ edx){
 
-	___imul32((__POINTER__)&eax, (__POINTER__)&edx, edx);
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax>>0x10)|(edx<<0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax = (int)eax>>0x10;
 

--- a/___36718h.c
+++ b/___36718h.c
@@ -34,10 +34,7 @@ void ___35dd0h(void);
 
 static __BYTE__ helper_color(__DWORD__ eax, __DWORD__ edx){
 
-	___imul32((__POINTER__)&eax, (__POINTER__)&edx, edx);
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax>>0x10)|(edx<<0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax = (int)eax>>0x10;
 

--- a/___38184h.c
+++ b/___38184h.c
@@ -49,9 +49,7 @@ void ___38184h_cdecl(__DWORD__ A1, __POINTER__ A2){
 	ebp -= eax;
 	ebx = eax+0x1;
 	edx -= ebp;
-	eax = edx;
-	edx = (int)edx>>0x1f;
-	___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ebx);
+	eax = edx / ebx;
 	ebp ^= ebp;
 	D(esp+0x34) = eax;
 	ebx = D(esp+0x30);

--- a/___3892ch.c
+++ b/___3892ch.c
@@ -68,10 +68,7 @@ __DWORD__ GET_FILE_SIZE(const char *);
 
 static __BYTE__ helper_color(__DWORD__ eax, __DWORD__ edx){
 
-	___imul32((__POINTER__)&eax, (__POINTER__)&edx, edx);
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax>>0x10)|(edx<<0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax = (int)eax>>0x10;
 

--- a/___3ab5ch.c
+++ b/___3ab5ch.c
@@ -65,7 +65,6 @@ void ___11378h_cdecl_float(float A1, float A2, float A3);
 
 __DWORD__ ___3ab5ch_cdecl(__DWORD__ A1){
 
-	long long 		ll_tmp;
 	__DWORD__ 		eax1, eax2;
 	__DWORD__ 		eax, ebx, ecx, edx, edi, esi, ebp;
 	__BYTE__ 		esp[0x5c];

--- a/__dfr_1d2a8h.c
+++ b/__dfr_1d2a8h.c
@@ -90,9 +90,7 @@ void ___1d2a8h(void){
 					if(ebp == 0xff) break;
 					D(esp+8) = 0xa;
 					ecx = ___5994ch();
-					edx = (int)ebx>>0x1f;
-					eax = ebx;
-					___idiv32((__POINTER__)&eax, (__POINTER__)&edx, D(esp+8));
+					edx = ebx % D(esp+8);
 					if(edx == 1){
 					
 						ebp = ___60b48h(D(___199fa0h)+5, 2);

--- a/menu___1e888h.c
+++ b/menu___1e888h.c
@@ -76,15 +76,11 @@ void dRChatbox_push(const char * line, int col);
 
 static __DWORD__ helper_color(__DWORD__ A0, __DWORD__ A1){
 
-	long long 	ll_tmp;
 	__DWORD__ 	eax, edx;
 
 	eax = A0;
 	edx = A1;
-	ll_tmp = (long long)(int)eax*(int)edx; edx = ll_tmp>>0x20; eax = ll_tmp;
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax >> 0x10)|(edx << 0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax = (int)eax>>0x10;
 	eax &= 0xff;

--- a/menu___3d4f0h.c
+++ b/menu___3d4f0h.c
@@ -28,15 +28,11 @@ void __DISPLAY_SET_PALETTE_COLOR(__DWORD__ b, __DWORD__ g, __DWORD__ r, __DWORD_
 
 static __DWORD__ helper_color(__DWORD__ A0, __DWORD__ A1){
 
-	long long 	ll_tmp;
 	__DWORD__ 	eax, edx;
 
 	eax = A0;
 	edx = A1;
-	ll_tmp = (long long)(int)eax*(int)edx; edx = ll_tmp>>0x20; eax = ll_tmp;
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax >> 0x10)|(edx << 0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax = (int)eax>>0x10;
 	eax &= 0xff;

--- a/menu___3da48h.c
+++ b/menu___3da48h.c
@@ -38,12 +38,7 @@ void dRally_Sound_release(void);
 
 static __BYTE__ helper_color(__DWORD__ eax, __DWORD__ edx){
 
-	long long 	ll_tmp;
-
-	ll_tmp = (long long)(int)eax*(int)edx; edx = ll_tmp>>0x20; eax = ll_tmp;
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax >> 0x10)|(edx << 0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax = (int)eax>>0x10;
 
@@ -52,7 +47,6 @@ static __BYTE__ helper_color(__DWORD__ eax, __DWORD__ edx){
 
 void menu___3da48h(void){
 
-	long long 	ll_tmp;
 	__DWORD__ 	rr, gg, bb, nn, cf;
 	__DWORD__ 	eax, ebx, ecx, edx, edi, esi, ebp;
 	__BYTE__ 	__esp[0x10+0x74];
@@ -76,7 +70,7 @@ void menu___3da48h(void){
 			edx = ebp;
 			eax = ebp;
 			edx = (int)edx>>0x1f;
-			edx = (long long)(int)eax%(int)esi;
+			edx = (int)eax%(int)esi;
 			if(edx != 0) menu___13a98h(0);	// SPINNING TIRE ICON
 			esi = D(esp+0x70);
 			ecx = 0;
@@ -148,7 +142,7 @@ void menu___3da48h(void){
 			edx = ebp;
 			eax = ebp;
 			edx = (int)edx>>0x1f;
-			edx = (long long)(int)eax%(int)esi;
+			edx = (int)eax%(int)esi;
 			if(edx != 0) menu___13a98h(0);	// SPINNING TIRE ICON
 			esi = 0;
 			D(esp+0x64) = 0;

--- a/race___40864h.c
+++ b/race___40864h.c
@@ -107,40 +107,28 @@ void race___40864h(void){
 
 		if((int)D(___243cdch) <= 0){
 
-			eax = D(___243ca0h);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x46);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x3c);
+			int n, A0;
+
+			A0 = D(___243ca0h);
+			n = A0 / 70;
+			eax = n / 60;
 			___4256ch_cdecl(___1d7810h, 0x6, 0x6, eax, 0x10, 0x207b, -6, 0);
-			eax = D(___243ca0h);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x46);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x3c);
+			edx = n % 60;
 			___4256ch_cdecl(___1d7810h, 0x6, 0x6, edx, 0x10, 0x2089, 6, 0);
-			eax = D(___243ca0h);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x46);
+			edx = A0 % 70;
 			___4256ch_cdecl(___1d7810h, 0x6, 0x6, (int)(1.42*(double)(int)edx), 0x10, 0x2097, 6, 0);
 		}
 		else {
 
-			eax = D(___243cb8h);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x46);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x3c);
+			int n, A0;
+
+			A0 = D(___243cb8h);
+			n = A0 / 70;
+			eax = n / 60;
 			___4256ch_cdecl(___1d7810h, 0x6, 0x6, eax, 0x10, 0x207b, -6, 0);
-			eax = D(___243cb8h);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x46);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x3c);
+			edx = n % 60;
 			___4256ch_cdecl(___1d7810h, 0x6, 0x6, edx, 0x10, 0x2089, 6, 0);
-			eax = D(___243cb8h);
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x46);
+			edx = A0 % 70;
 			___4256ch_cdecl(___1d7810h, 0x6, 0x6, (int)(1.42*(double)(int)edx), 0x10, 0x2097, 6, 0);
 			D(___243cdch) -= D(___243334h);
 			if((int)D(___243cdch) < 0) D(___243cdch) = 0;

--- a/race___40db4h.c
+++ b/race___40db4h.c
@@ -24,106 +24,32 @@ void race___40db4h(void){
 	__DWORD__ 		eax, ebx, ecx, edx, edi, esi, ebp;
 	__BYTE__ 		esp[4];
 	struct_35e_t *	s_35e;
+	int n;
 
 
 	s_35e = (struct_35e_t *)___1e6ed0h;
 
-		esi = D(___243cd4h);
-		edi = D(___243ca0h);
-		eax = getCounter(3);
-		edx = D(___243330h);
-		eax -= edx;
-		D(___243334h) = eax;
-		eax = getCounter(3);
-		edx = D(___243334h);
-		ebx = 0x20000;
-		edx <<= 0x10;
-		D(___243330h) = eax;
-		eax = 0;
-		eax = (eax >> 0x10)|(edx << 0x10);
-		edx = (int)edx>>0x10;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ebx);
-		//idiv    ebx
-		ebx = getCounter(1);
-		D(___24332ch) = eax;
-		if((int)ebx <= 0xbe) goto ___40ef4h;
-		eax = 0x35e*D(MY_CAR_IDX);
-		if(s_35e[eax/0x35e].Finished != 0) goto ___40ef4h;
-		ebx = 0x46;
-		eax = D(___243334h);
-		esi = D(___243cd4h);
-		edi = D(___243ca0h);
-		esi += eax;
-		edi += eax;
-		edx = esi;
-		eax = esi;
-		edx = (int)edx>>0x1f;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ebx);
-		//idiv    ebx
-		edx = eax;
-		ecx = 0x3c;
-		edx = (int)edx>>0x1f;
-		ebx = eax;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ecx);
-		//idiv    ecx
-		D(___1a10a0h) = eax;
-		edx = ebx;
-		eax = ebx;
-		edx = (int)edx>>0x1f;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ecx);
-		//idiv    ecx
-		ebx = 0x46;
-		D(___1a10a8h) = edx;
-		edx = esi;
-		eax = esi;
-		edx = (int)edx>>0x1f;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ebx);
-		//idiv    ebx
-		D(esp) = edx;
-		edx = edi;
-		eax = edi;
-		edx = (int)edx>>0x1f;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ebx);
-		//idiv    ebx
-		edx = eax;
-		edx = (int)edx>>0x1f;
-		ebx = eax;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ecx);
-		//idiv    ecx
-		LAP_PREVIOUS_MIN = eax;
-		edx = ebx;
-		eax = ebx;
-		edx = (int)edx>>0x1f;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ecx);
-		//idiv    ecx
-		ebx = 0x46;
-		LAP_PREVIOUS_SEC = edx;
-		edx = edi;
-		eax = edi;
-		edx = (int)edx>>0x1f;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ebx);
-		//idiv    ebx
-		D(___1a1090h) = (int)((double)(int)D(esp)*1.42);
-		D(esp) = edx;
-		LAP_PREVIOUS_100 = (int)(1.42*(double)(int)D(esp));
-		D(___243cd4h) = esi;
-		D(___243ca0h) = edi;
-___40ef4h:
-		edi = D(___243ca0h);
-		eax = D(___243cdch);
-		esi = D(___243cd4h);
-		if((int)eax <= 0) goto ___40f28h;
-		edx = D(___243cdch);
-		eax = D(___243334h);
-		edx -= eax;
-		D(___243cdch) = edx;
-		if((int)edx >= 0) goto ___40f28h;
-		ecx = 0;
-		D(___243cdch) = ecx;
-___40f28h:
-		D(___243cd4h) = esi;
-		D(___243ca0h) = edi;
-		race___40864h();
-		esi = D(___243cd4h);
-		return;
+
+	D(___243334h) = getCounter(3) - D(___243330h);
+	D(___243330h) = getCounter(3);
+	D(___24332ch) = D(___243334h) << 15;
+
+	if ((int)getCounter(1) > 0xbe) {
+
+		if (s_35e[D(MY_CAR_IDX)].Finished == 0) {
+
+			D(___243cd4h) += D(___243334h);
+			D(___243ca0h) += D(___243334h);
+			n = D(___243cd4h) / 70;
+			D(___1a10a0h) = n / 60;
+			D(___1a10a8h) = n % 60;
+			D(___1a1090h) = (int)(1.42 * (double)(int)(D(___243cd4h) % 70));
+			n = D(___243ca0h) / 70;
+			LAP_PREVIOUS_MIN = n / 60;
+			LAP_PREVIOUS_SEC = n % 60;
+			LAP_PREVIOUS_100 = (int)(1.42 * (double)(int)(D(___243ca0h) % 70));
+		}
+	}
+
+	race___40864h();
 }

--- a/race___40f48h.c
+++ b/race___40f48h.c
@@ -57,36 +57,25 @@ void DamageWarning(void);
 static void helper00(int A0){
 
     int     eax, edx;
+    int n;
 
-    eax = A0;
-    edx = (int)eax>>0x1f;
-    ___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x46);
-    edx = (int)eax>>0x1f;
-    ___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x3c);
+    n = A0 / 70;
+    eax = n / 60;
     ___4256ch_cdecl(___1d7810h, 6, 6, eax, 16, 0x587b-0x40+CURRENT_VIEWPORT_X, -6, 0);
 
-    eax = A0;
-    edx = (int)eax>>0x1f;
-    ___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x46);
-    edx = (int)eax>>0x1f;
-    ___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x3c);
+    edx = n % 60;
     ___4256ch_cdecl(___1d7810h, 6, 6, edx, 16, 0x5889-0x40+CURRENT_VIEWPORT_X, 6, 0);
 
-    eax = A0;
-    edx = (int)eax>>0x1f;
-    ___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x46);
+    edx = A0 % 70;
 
     ___4256ch_cdecl(___1d7810h, 6, 6, (int)(1.42*(double)(int)edx), 16, 0x5897-0x40+CURRENT_VIEWPORT_X, 6, 0);
 }
 
 static int helper01(int A0){
 
-    int     eax, edx;
+    int     eax;
 
-    edx = 0x10000*A0;
-    eax = 0x10000*edx;
-    edx = (int)edx>>0x10;
-    ___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x20000);
+    eax = A0 << 15;
 
     return eax;
 }
@@ -408,7 +397,7 @@ void race___40f48h(void){
         L(eax) -= L(edx);
         X(eax) <<= 8;
         X(edx) = (short)X(eax)>>0xf;
-        ___idiv16((__POINTER__)&X(eax), (__POINTER__)&X(edx), X(ebx));
+        eax = (X(edx) << 16 | X(eax)) / X(ebx);
         X(esi) = X(eax);
 
         eax = 0;

--- a/race___40f48h.c
+++ b/race___40f48h.c
@@ -300,11 +300,7 @@ void race___40f48h(void){
 
         if((int)eax <= 0){
 
-            eax = D(4*ebx+___1c9f00h);
-            ___imul32((__POINTER__)&eax, (__POINTER__)&edx, D(___24332ch));
-            eax += 0x8000;
-            edx += !!(eax < 0x8000);
-            eax = (eax >> 0x10)|(edx << 0x10);
+            eax = (int)D(4 * ebx + ___1c9f00h) / 0x10000 * D(___24332ch);
             D(4*ebx+___1c9ef0h) += eax;
             eax = D(4*ebx+___1c9ef0h)+0x8000;
             eax = (int)eax>>0x10;
@@ -313,11 +309,7 @@ void race___40f48h(void){
         }
         else {
 
-            eax = D(4*ebx+___1c9f00h);
-            ___imul32((__POINTER__)&eax, (__POINTER__)&edx, D(___24332ch));
-            eax += 0x8000;
-            edx += !!(eax < 0x8000);
-            eax = (eax >> 0x10)|(edx << 0x10);
+            eax = (int)D(4 * ebx + ___1c9f00h) / 0x10000 * D(___24332ch);
             D(4*ebx+___1c9ef0h) += eax;
             eax = D(4*ebx+___1c9ef0h)+0x8000;
             eax = (int)eax>>0x10;

--- a/race___45a24h.c
+++ b/race___45a24h.c
@@ -21,9 +21,7 @@ static __DWORD__ helper_color(__BYTE__ b){
 
 	edx = b;
 	edx <<= 0x10;
-	eax = edx<<0x10;
-	edx = (int)edx>>0x10;
-	___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x3f0000);
+	eax = edx / 63;
 
 	return eax;
 }

--- a/race___45a24h.c
+++ b/race___45a24h.c
@@ -28,11 +28,7 @@ static __DWORD__ helper_color(__BYTE__ b){
 
 static __BYTE__ helper_color2(__DWORD__ eax, __DWORD__ edx){
 
-
-	___imul32((__POINTER__)&eax, (__POINTER__)&edx, edx);
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax>>0x10)|(edx<<0x10);
+	eax = edx / 0x10000 * eax;
 	eax = eax+0x8000;
 	eax = (int)eax>>0x10;
 
@@ -41,10 +37,7 @@ static __BYTE__ helper_color2(__DWORD__ eax, __DWORD__ edx){
 
 static __BYTE__ helper_color3(__DWORD__ eax, __DWORD__ edx, __DWORD__ ecx){
 
-	___imul32((__POINTER__)&eax, (__POINTER__)&edx, edx);
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax>>0x10)|(edx<<0x10);
+	eax = edx / 0x10000 * eax;
 	ecx <<= 0x10;
 	ecx -= eax;
 	ecx += 0x8000;

--- a/race___478c8h_p.c
+++ b/race___478c8h_p.c
@@ -61,7 +61,6 @@ static void ___47304h(void){
 
 	__DWORD__ 	eax, ebx, ecx, edx, edi, esi, ebp;
     int     i, j, n, k, l;
-    long long   ll_tmp;
 
 
     ebp = 0;
@@ -128,12 +127,12 @@ static void ___47304h(void){
                 ___243e74h[n].__0 = 0x10000*___1a30a0h[D(___2432e0h)];
                 ___243e74h[n].__4 = 0xc40000;
 
-                ll_tmp = (int)(D(___2432cch)+(CURRENT_VIEWPORT_X>>0x1)+0x39-___1a30a0h[D(___2432e0h)]);
-                ll_tmp <<= 0x10;
-                ___243e74h[n].__8 = ll_tmp/70;
-                ll_tmp = (int)(D(___2432d0h)-132);
-                ll_tmp <<= 0x10;
-                ___243e74h[n].__C = ll_tmp/70;
+				k = (int)(D(___2432cch) + (CURRENT_VIEWPORT_X >> 0x1) + 0x39 - ___1a30a0h[D(___2432e0h)]);
+				k <<= 0x10;
+				___243e74h[n].__8 = k / 70;
+				k = (int)(D(___2432d0h) - 132);
+				k <<= 0x10;
+				___243e74h[n].__C = k / 70;
                 ___243e74h[n]._20 = 0;
                 D(___2432e8h) += 0x4;
                 D(___2432d0h) += 0x4;

--- a/race___478c8h_p.c
+++ b/race___478c8h_p.c
@@ -363,8 +363,7 @@ void race___47ed8h(__DWORD__ A0){
 	while(1){
 
 		eax = rand_watcom106();
-		edx = (int)eax>>0x1f;
-		___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0x13c);
+		edx = eax % 0x13c;
 		___1a30a0h[ebx] = edx;
 		ebx++;
 		if(ebx == 100) break;

--- a/race___4c434h.c
+++ b/race___4c434h.c
@@ -322,19 +322,19 @@ void race___4c434h(void){
 				eax = rand_watcom106();
 				ebx = 2*s_35e[D(___243c60h)].__16a+1;
 				edx = (int)eax>>0x1f;
-				edx = (long long)(int)eax%(int)ebx;
+				edx = (int)eax%(int)ebx;
 				edx = edx-s_35e[D(___243c60h)].__16a;
 				D(esp+0x5c) = edx;
 				s_35e[D(___243c60h)].__162 = (float)(double)(int)D(esp+0x5c);
 				eax = rand_watcom106();
 				ebx = 2*s_35e[D(___243c60h)].__16a+1;
 				edx = (int)eax>>0x1f;
-				edx = (long long)(int)eax%(int)ebx;
+				edx = (int)eax%(int)ebx;
 				edi = s_35e[D(___243c60h)].__16e+1;
 				D(esp+0x5c) = edx-s_35e[D(___243c60h)].__16a;
 				eax = edi;
 				edx = (int)eax>>0x1f;
-				edx = (long long)(int)eax%5;
+				edx = (int)eax%5;
 				s_35e[D(___243c60h)].__16e = edi;
 				s_35e[D(___243c60h)].__166 = (float)(int)D(esp+0x5c);
 

--- a/race___5209ch.c
+++ b/race___5209ch.c
@@ -84,10 +84,7 @@ void race___5209ch(void){
 
 				while(1){
 					eax = rand_watcom106();
-					edx = eax;
-					ebx = 0xc;
-					edx = (int)edx>>0x1f;
-					___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ebx);
+					edx = eax % 0xc;
 					D(esp+0x30) = edx;
 					if(B(esp+edx) != 1) break;
 				}
@@ -124,10 +121,7 @@ void race___5209ch(void){
 							if((int)D(esp+0x18) < 4){
 
 								eax = rand_watcom106();
-								edx = eax;
-								ecx = 0x64;
-								edx = (int)edx>>0x1f;
-								___idiv32((__POINTER__)&eax, (__POINTER__)&edx, ecx);
+								edx = eax % 0x64;
 								eax = 0x94*D(MY_CAR_IDX);
 
 								if(D(eax+___1de580h+0x2c) == 0){
@@ -366,8 +360,7 @@ void race___5209ch(void){
 			D(___1f2488h+D(esp+0x2c)+8) = 0;
 			D(___196dd0h) = 0x118;
 			eax = rand_watcom106();
-			edx = (int)eax>>0x1f;
-			___idiv32((__POINTER__)&eax, (__POINTER__)&edx, 0xc8);
+			edx = eax % 0xc8;
 			D(___1f2488h+D(esp+0x2c)+0xc) = edx+0x12c;
 		}
 

--- a/race___53464h.c
+++ b/race___53464h.c
@@ -77,7 +77,7 @@ static __DWORD__ helper00(int val0, int val1){
 	__DWORD__ 	eax, edx;
 
 	edx = 0x100*val0;
-	eax = (long long)(int)edx/val1;
+	eax = (int)edx/val1;
 	eax = eax+0x80;
 	eax = (int)eax>>8;
 

--- a/shop___28e40h.c
+++ b/shop___28e40h.c
@@ -77,7 +77,7 @@ void shop___28e40h(void){
 
 
 	D(esp+0x50) = (s_6c[D(___1a1ef8h)].refund+3)/4;
-	eax = (long long)(int)cdp[s_6c[D(___1a1ef8h)].car].price_repair/10;
+	eax = (int)cdp[s_6c[D(___1a1ef8h)].car].price_repair/10;
 	esi = s_6c[D(___1a1ef8h)].damage*eax;
 
 	if(D(___185a14h_UseWeapons) != 0) esi = (int)esi/4;

--- a/shop_main.c
+++ b/shop_main.c
@@ -146,7 +146,6 @@ static __DWORD__ checkCheat(__BYTE__ * p){
 // ___2b8ach
 void shop_main(void){
 
-	long long 	ll_tmp;
 	__DWORD__ 	eax, ebx, ecx, edx, edi, esi, ebp;
 	__BYTE__ 	__esp[0x20+0x40];
 	int 	bool_tmp, cond1, cond2, cond3, cond4;
@@ -322,11 +321,7 @@ void shop_main(void){
 
 		edx = ebp;
 		eax = ebp;
-		edx = (int)edx>>0x1f;
-		ll_tmp = edx;
-		ll_tmp <<= 0x20;
-		ll_tmp += eax;
-		edx = ll_tmp%2;
+		edx = eax % 2;
 
 		if(edx != 0){
 			if(LONGCOND&&(s_6c[D(___1a1ef8h)].loanshark_counter != 4)){
@@ -347,11 +342,7 @@ void shop_main(void){
 
 		edx = ebp;
 		eax = ebp;
-		edx = (int)edx>>0x1f;
-		ll_tmp = edx;
-		ll_tmp <<= 0x20;
-		ll_tmp += eax;
-		edx = ll_tmp%2;
+		edx = eax % 2;
 
 		if(edx != 0){
 			if(LONGCOND&&(s_6c[D(___1a1ef8h)].loanshark_counter != 4)){
@@ -376,12 +367,9 @@ void shop_main(void){
 		D(esp+0x20) = 0;
 		while(1){
 
-			ll_tmp = (long long)(int)___19eb50h[D(esp+0x20)].r*(long long)(int)D(esp+0x2c);
-			r = ((ll_tmp+0x8000)>>0x10)&0xff;
-			ll_tmp = (long long)(int)___19eb50h[D(esp+0x20)].g*(long long)(int)D(esp+0x2c);
-			g = ((ll_tmp+0x8000)>>0x10)&0xff;
-			ll_tmp = (long long)(int)___19eb50h[D(esp+0x20)].b*(long long)(int)D(esp+0x2c);
-			b = ((ll_tmp+0x8000)>>0x10)&0xff;
+			r = (((int)___19eb50h[D(esp + 0x20)].r * (int)D(esp + 0x2c) + 0x8000) >> 0x10) & 0xff;
+			g = (((int)___19eb50h[D(esp + 0x20)].g * (int)D(esp + 0x2c) + 0x8000) >> 0x10) & 0xff;
+			b = (((int)___19eb50h[D(esp + 0x20)].b * (int)D(esp + 0x2c) + 0x8000) >> 0x10) & 0xff;
 			__DISPLAY_SET_PALETTE_COLOR(b, g, r, D(esp+0x20));
 			D(esp+0x20)++;
 			if((int)D(esp+0x20) >= 0x60) break;
@@ -390,12 +378,9 @@ void shop_main(void){
 		D(esp+0x20) = 0;
 		while(1){
 
-			ll_tmp = (long long)(int)___19eb50h[D(esp+0x20)+0x80].r*(long long)(int)D(esp+0x2c);
-			r = ((ll_tmp+0x8000)>>0x10)&0xff;
-			ll_tmp = (long long)(int)___19eb50h[D(esp+0x20)+0x80].g*(long long)(int)D(esp+0x2c);
-			g = ((ll_tmp+0x8000)>>0x10)&0xff;
-			ll_tmp = (long long)(int)___19eb50h[D(esp+0x20)+0x80].b*(long long)(int)D(esp+0x2c);
-			b = ((ll_tmp+0x8000)>>0x10)&0xff;
+			r = (((int)___19eb50h[D(esp + 0x20) + 0x80].r * (int)D(esp + 0x2c) + 0x8000) >> 0x10) & 0xff;
+			g = (((int)___19eb50h[D(esp + 0x20) + 0x80].g * (int)D(esp + 0x2c) + 0x8000) >> 0x10) & 0xff;
+			b = (((int)___19eb50h[D(esp + 0x20) + 0x80].b * (int)D(esp + 0x2c) + 0x8000) >> 0x10) & 0xff;
 			__DISPLAY_SET_PALETTE_COLOR(b, g, r, D(esp+0x20)+0x80);
 			D(esp+0x20)++;
 			if((int)D(esp+0x20) >= 0x80) break;
@@ -900,12 +885,9 @@ ___2c687h:
 			D(esp+0x20) = 0;
 			while(1){
 
-				ll_tmp = (long long)(int)___19eb50h[D(esp+0x20)+0x20].r*0x64;
-				r = ((ll_tmp+0x8000)>>0x10)&0xff;
-				ll_tmp = (long long)(int)___19eb50h[D(esp+0x20)+0x20].g*0x64;
-				g = ((ll_tmp+0x8000)>>0x10)&0xff;
-				ll_tmp = (long long)(int)___19eb50h[D(esp+0x20)+0x20].b*0x64;
-				b = ((ll_tmp+0x8000)>>0x10)&0xff;
+				r = (((int)___19eb50h[D(esp + 0x20) + 0x20].r * 0x64 + 0x8000) >> 0x10) & 0xff;
+				g = (((int)___19eb50h[D(esp + 0x20) + 0x20].g * 0x64 + 0x8000) >> 0x10) & 0xff;
+				b = (((int)___19eb50h[D(esp + 0x20) + 0x20].b * 0x64 + 0x8000) >> 0x10) & 0xff;
 				__DISPLAY_SET_PALETTE_COLOR(b, g, r, D(esp+0x20)+0x20);
 				D(esp+0x20)++;
 				if((int)D(esp+0x20) >= 0xe0) break;

--- a/shop_main.c
+++ b/shop_main.c
@@ -161,12 +161,7 @@ void shop_main(void){
 	D(esp+0x18) = 0;
 	D(esp+0xc) = (s_6c[D(___1a1ef8h)].refund+3)/4;
 	ebx = 0x6c*D(___1a1ef8h);
-	eax = D(___18e298h+0x6e0*s_6c[ebx/0x6c].car+0x6dc);
-	edx = (int)eax>>0x1f;
-	ll_tmp = edx;
-	ll_tmp <<= 0x20;
-	ll_tmp += eax;
-	eax = ll_tmp/0xa;
+	eax = D(___18e298h + 0x6e0 * s_6c[ebx / 0x6c].car + 0x6dc) / 0xa;
 	edx = (int)s_6c[ebx/0x6c].damage*(int)eax;
 
 	if(D(___185a14h_UseWeapons) != 0) edx = (int)edx/2;

--- a/sound_thread.c
+++ b/sound_thread.c
@@ -157,7 +157,6 @@ void switch_ZZ(__BYTE__);
 static __DWORD__ static_CX(__WORD__ A1, int Finetune){
 
 	__DWORD__ 		eax;
-	__QWORD__ 		ll_tmp;
 
 //	__DWORD__ 		period_oct;
 //	__DWORD__ 		note_st3period;
@@ -228,7 +227,6 @@ void ___6ef2ch(void){
 
     __DWORD__   eax, ebx, ecx, edx, esi, edi, ebp;
 	int 	hi_channel_id;
-    long long   ll_tmp;
 
 	if(S3M_UpdatePosition != 0){
 

--- a/underground_main.c
+++ b/underground_main.c
@@ -72,14 +72,7 @@ void dRally_Sound_setMasterVolume(__DWORD__ vol);
 
 static __BYTE__ helper_color(__DWORD__ eax, __DWORD__ edx){
 
-	long long 	ll_tmp;
-
-	ll_tmp = (long long)(int)eax*(int)edx;
-	edx = ll_tmp>>0x20;
-	eax = ll_tmp;
-	eax += 0x8000;
-	edx += !!(eax < 0x8000);
-	eax = (eax>>0x10)|(edx<<0x10);
+	eax = edx / 0x10000 * eax;
 	eax += 0x8000;
 	eax = (int)eax>>0x10;
 
@@ -113,7 +106,6 @@ static void helper_continue_anim(void){
 // ___2ee78h
 void underground_main(void){
 
-	long long ll_tmp;
 	__DWORD__ 	rr, gg, bb, nn;
 	__DWORD__ 	eax, ebx, ecx, edx, edi, esi, ebp;
 	__BYTE__ 	__esp[0x20+0x20];


### PR DESCRIPTION
I replaced all of the instances with idiv32 and idiv16 calls with divisions and modulos. Fortunately 64-bit math was not necessary due to the limited size of the operands. 