### PR TITLE
use C99 stdbool.h and __USE_POSIX for time.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MSBUILD := MSBuild.exe
 DEFINES := -DDR_MULTIPLAYER -DIPXNET -DDR_LETTERBOX #-DDR_CDCHECK
 INCLUDES := -I/usr/include/SDL2
 FLAGS ?= -O3
-FLAGS += -Werror -Wno-unused-result
+FLAGS += -std=c99 -Werror -Wno-unused-result
 LDFLAGS := -lm -lSDL2 -lSDL2_net
 
 OBJS := data.o bss.o

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The main goal of this project is to create a port of Death Rally (1996) running natively on Linux and BSD based operating systems.
 
 #### Linux requirements
-* GCC/Clang C compiler
+* GCC/Clang C compiler supporting C99/POSIX
 * GNU/Make
 * SDL2
 

--- a/db_ipx.c
+++ b/db_ipx.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 #include "drally_ipx.h"
 
@@ -11,10 +12,6 @@
 #define IPXBUFFERSIZE 	1424
 
 #define CONVIPX(hostvar) hostvar[0], hostvar[1], hostvar[2], hostvar[3], hostvar[4], hostvar[5]
-
-typedef int             bool;
-#define true            1
-#define false           0
 
 typedef unsigned char   Bit8u;
 typedef signed short    Bit16s;

--- a/drally.h
+++ b/drally.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#define __USE_POSIX 1
 #include <time.h>
 #include <ctype.h>
 #include <SDL2/SDL.h>


### PR DESCRIPTION
- Use -std=c99
- Avoids warning/error with gcc-14/15 about bool being a typedef
- Avoids localtime_r not being defined with -std=c99